### PR TITLE
Add special characters to generic rule

### DIFF
--- a/gitleaks-extended.toml
+++ b/gitleaks-extended.toml
@@ -6,7 +6,7 @@ path = "gitleaks.toml"
 [[rules]]
 description = "Generic API Key 2"
 id = "generic-api-key-2"
-regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=!@#$%^&*()+]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
 entropy = 3.5
 keywords = [


### PR DESCRIPTION
The rule was not catching special characters, so e.g. a secret like this was not getting detected:
`"CACHE_SECRET" = "TBD1234!@#$asdf"`

Now it is detected.